### PR TITLE
add sep v2

### DIFF
--- a/Missionframework/presets/blufor/rhs_usaf_des.sqf
+++ b/Missionframework/presets/blufor/rhs_usaf_des.sqf
@@ -129,6 +129,7 @@ heavy_vehicles = [
     ["RHS_M6",300,250,175],                                             // M6A2
     ["rhsusf_m1a1aim_tuski_d",400,350,225],                             // M1A1SA (Tusk I)
     ["rhsusf_m1a2sep1tuskiid_usarmy",500,400,250],                      // M1A2SEPv1 (Tusk II)
+    ["rhsusf_m1a2sep2tuskiid_usarmy",500,400,250],                      // M1A2SEPv2 (Tusk II)
     ["rhsusf_m109d_usarmy",600,1250,300]                                // M109A6
 ];
 

--- a/Missionframework/presets/blufor/rhs_usaf_wdl.sqf
+++ b/Missionframework/presets/blufor/rhs_usaf_wdl.sqf
@@ -129,6 +129,7 @@ heavy_vehicles = [
     ["RHS_M6_wd",300,250,175],                                          // M6A2
     ["rhsusf_m1a1aim_tuski_wd",400,350,225],                            // M1A1SA (Tusk I)
     ["rhsusf_m1a2sep1tuskiiwd_usarmy",500,400,300],                     // M1A2SEPv1 (Tusk II)
+    ["rhsusf_m1a2sep2tuskiiwd_usarmy",500,400,300],                     // M1A2SEPv2 (Tusk II)
     ["rhsusf_m109_usarmy",600,1250,300],                                // M109A6
     ["rhsusf_M142_usarmy_WD",650,1500,350]                              // M142 HIMARS
 ];


### PR DESCRIPTION
add preset for sep v2 for blufor faction

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| Needs wipe? | no |

### Description:

Adds the M1A2 Tusk II Sep V2

### Content:

``["rhsusf_m1a2sep2tuskiid_usarmy",500,400,250],                      // M1A2SEPv2 (Tusk II)``

### Successfully tested on:
- [ ] Local MP
- [ ] Dedicated MP

