### PR TITLE
Removed BMP2 replaced with BMP1D with no TOW for pilots

### DIFF
--- a/Missionframework/presets/opfor/takistan.sqf
+++ b/Missionframework/presets/opfor/takistan.sqf
@@ -66,8 +66,7 @@ opfor_vehicles = [
     "LOP_TKA_UAZ_DshKM",                                                // UAZ-3151 (DShKM)
     "LOP_TKA_UAZ_AGS",                                                  // UAZ-3151 (AGS-30)
     "LOP_TKA_UAZ_SPG",                                                  // UAZ-3151 (SPG-9)
-    "LOP_TKA_BMP2",                                                     // BMP-2
-    "LOP_TKA_BMP2D",                                                    // BMP-2D
+    "LOP_TKA_BMP1D",                                                     // BMP-2
     "LOP_TKA_BTR70",                                                    // BTR-70
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V

--- a/Missionframework/presets/opfor/takistan.sqf
+++ b/Missionframework/presets/opfor/takistan.sqf
@@ -70,10 +70,10 @@ opfor_vehicles = [
 <<<<<<< HEAD
     "LOP_TKA_BMP1D",                                                    // BMP-1D
 =======
-    "LOP_TKA_BMP1D",                                                     // BMP-2
+    "LOP_TKA_BMP1D",                                                    // BMP-1D
 >>>>>>> develop
 =======
-    "LOP_TKA_BMP1D",                                                     // BMP-2
+    "LOP_TKA_BMP1D",                                                    // BMP-1D
 >>>>>>> develop
     "LOP_TKA_BTR70",                                                    // BTR-70
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V

--- a/Missionframework/presets/opfor/takistan.sqf
+++ b/Missionframework/presets/opfor/takistan.sqf
@@ -66,8 +66,11 @@ opfor_vehicles = [
     "LOP_TKA_UAZ_DshKM",                                                // UAZ-3151 (DShKM)
     "LOP_TKA_UAZ_AGS",                                                  // UAZ-3151 (AGS-30)
     "LOP_TKA_UAZ_SPG",                                                  // UAZ-3151 (SPG-9)
-    "LOP_TKA_BMP2",                                                     // BMP-2
-    "LOP_TKA_BMP2D",                                                    // BMP-2D
+<<<<<<< HEAD
+    "LOP_TKA_BMP1D",                                                    // BMP-1D
+=======
+    "LOP_TKA_BMP1D",                                                     // BMP-2
+>>>>>>> develop
     "LOP_TKA_BTR70",                                                    // BTR-70
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V
@@ -93,9 +96,8 @@ opfor_battlegroup_vehicles = [
     "LOP_TKA_UAZ_SPG",                                                  // UAZ-3151 (SPG-9)
     "LOP_TKA_Ural_open",                                                // Ural-4320 Transport
     "LOP_TKA_Ural",                                                     // Ural-4320 Transport (Covered)
-    "LOP_TKA_BMP2",                                                     // BMP-2
-    "LOP_TKA_BMP2D",                                                    // BMP-2D
     "LOP_TKA_BTR70",                                                    // BTR-70
+    "LOP_TKA_BMP1D",                                                    // BMP-1D
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V
     "LOP_TKA_T55",                                                      // T-55A
@@ -128,7 +130,6 @@ opfor_troup_transports = [
     "LOP_TKA_Ural",                                                     // Ural-4320 Transport (Covered)
     "LOP_TKA_BTR70",                                                    // BTR-70
     "LOP_TKA_BMP1D",                                                    // BMP-1D
-    "LOP_TKA_BMP2D",                                                    // BMP-2D
     "LOP_TKA_Mi8MT_Cargo",                                              // Mi-8MT (Cargo)
     "LOP_TKA_Mi24V_AT",                                                 // Mi-24P (AT)
     "LOP_TKA_Mi24V_UPK23"                                               // Mi-24V (UPK)

--- a/Missionframework/presets/opfor/takistan.sqf
+++ b/Missionframework/presets/opfor/takistan.sqf
@@ -66,15 +66,9 @@ opfor_vehicles = [
     "LOP_TKA_UAZ_DshKM",                                                // UAZ-3151 (DShKM)
     "LOP_TKA_UAZ_AGS",                                                  // UAZ-3151 (AGS-30)
     "LOP_TKA_UAZ_SPG",                                                  // UAZ-3151 (SPG-9)
-<<<<<<< HEAD
-<<<<<<< HEAD
     "LOP_TKA_BMP1D",                                                    // BMP-1D
-=======
     "LOP_TKA_BMP1D",                                                    // BMP-1D
->>>>>>> develop
-=======
     "LOP_TKA_BMP1D",                                                    // BMP-1D
->>>>>>> develop
     "LOP_TKA_BTR70",                                                    // BTR-70
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V
     "LOP_TKA_ZSU234",                                                   // ZSU-23-4V


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes <!-- don't forget to update CHANGELOG.md file --> | I do not know how to do this?
| Needs wipe? | no <!-- set to yes if save needs to be wiped to use new feature --> | I am not sure what that means

### Description:

<!--
BMP2D and BMP2 in liberation has tow which we got complaints on. Replaced with BMP1D no TOW 
-->

### Content:
- [LOP_TKA_BMP1D ] Content part

<!--
Add things which are part of this pull request as checkboxes
to show if it's already finished and already part of the pull request.
-->

### Successfully tested on:
- [ ] Local MP
- [ ] Dedicated MP
Need help with testing part 
<!--
As soon as you've tested your feature on the listed environment you can check the checkbox.
It has to work without any issues and errors in your own tests.
-->
